### PR TITLE
Options for Using

### DIFF
--- a/Distribution/NuGet.apls
+++ b/Distribution/NuGet.apls
@@ -194,9 +194,12 @@ mine←name{(((≢⍺)↑¨⍕¨⍵)∊⊂⍺)/⍵}assemblies
    ⍝
    ⍝ The key-value part of args is interpreted as a map from options to values. Currently the following options are supported:
    ⍝ * project_dir is the project directory; it must be signified if args is a pure list of key-value pairs
-   ⍝ * include_primary is a boolean signifying whether (1) or not (0) the path to the primary DLL is included in the output
+   ⍝ * include_primary is a boolean signifying whether (1) or not (0) the path to the primary DLL is included in the output.
+   ⍝   Its standard value is 1.
    ⍝ * exclude_pkgs is a list of package names (without version number!) to be excluded in the output
+   ⍝   Its standard value is ⍬
    ⍝ * include_pkgs is a list of package names (without version number!) to be included in the output
+   ⍝   Its standard value is ⍬
    ⍝ The parameter exclude_pkgs takes precedence over include_pkgs and giving include_pkgs a value of ⍬ means to include all packages.
 
  :If 2>|≡args

--- a/Distribution/NuGet.apls
+++ b/Distribution/NuGet.apls
@@ -185,38 +185,58 @@ mine←name{(((≢⍺)↑¨⍕¨⍵)∊⊂⍺)/⍵}assemblies
  r←'Created project file "',csproj,'"'
 ∇
 
-∇ using_paths←Using project_dir;deps;d;k;v;t;pkg_name;pkgrt;dll;pkgs;ns;jsname;tgts;z;dlls;children;p;folder;name
+∇ using_paths←Using args;deps;d;k;v;t;pkg_name;pkgrt;dll;pkgs;ns;jsname;tgts;z;dlls;children;p;folder;name;project_dir;opts;opts_mat;include_primary;exclude_pkgs;include_pkgs;all_pkgs
+
+ :If 2>|≡args
+     project_dir opts←args ⍬
+ :ElseIf 2>|≡⊃args
+     project_dir←⊃args
+     opts←1↓args
+ :Else
+     project_dir←⊃opts_mat⌷⍨2,(1⌷opts_mat←⍉↑args)⍳⊂'project_dir'
+     opts←args
+ :EndIf
+
+ include_primary include_pkgs exclude_pkgs←1 (⊂⍬) (⊂⍬){⊃(opts_mat,⍺)⌷⍨2,(1⌷opts_mat←⍉↑args)⍳⊂⍵}¨'include_primary' 'include_pkgs' 'exclude_pkgs'
+
  jsname←7162⌶ ⍝ JSON Translate Name
- pkgs←Packages project_dir
+
+ pkgs←(~exclude_pkgs∊⍥⎕C⍨1⊃¨all_pkgs)/all_pkgs←Packages project_dir
+ :If 0<≢include_pkgs
+    pkgs←(include_pkgs∊⍥⎕C⍨1⊃¨pkgs)/pkgs
+ :EndIf
+
+
  :If 0≠≢deps←findfile project_dir,'/*.deps.json'
  :OrIf 0≠≢deps←findfile project_dir,'/published/*.deps.json'
-     
-          ⍝ ↓↓↓ This code is a namespace-based version of what follows, in case that turns out to be useful someday
-          ⍝ ns←⎕JSON ⊃⎕NGET deps
-          ⍝ z←ns.targets⍎0 jsname ns.runtimeTarget.name
-          ⍝ children←z.⎕NL-9 ⍝ refs to all children
-          ⍝ children←(({(¯1+⍵⍳¨'/')↑¨⍵}1 jsname¨children)∊⊃¨pkgs)/children
-          ⍝ dlls←1 jsname¨⊃,/(,z⍎⍕children).runtime.⎕NL -9
-          ⍝ dlls←(∊¨1↓¨⎕NPARTS¨dlls)~⊂'nuget-packages.dll'
-          ⍝ ↑↑↑
-     
+
+     ⍝ ↓↓↓ This code is a namespace-based version of what follows, in case that turns out to be useful someday
+     ⍝ ns←⎕JSON ⊃⎕NGET deps
+     ⍝ z←ns.targets⍎0 jsname ns.runtimeTarget.name
+     ⍝ children←z.⎕NL-9 ⍝ refs to all children
+     ⍝ children←(({(¯1+⍵⍳¨'/')↑¨⍵}1 jsname¨children)∊⊃¨pkgs)/children
+     ⍝ dlls←1 jsname¨⊃,/(,z⍎⍕children).runtime.⎕NL -9
+     ⍝ dlls←(∊¨1↓¨⎕NPARTS¨dlls)~⊂'nuget-packages.dll'
+     ⍝ ↑↑↑
+
      (d k v t)←↓⍉⎕JSON ⎕OPT'Format' 'M'⊃⎕NGET deps
-          ⍝ Depth, Key, Value, Type
+     ⍝ Depth, Key, Value, Type
      {}2{p[⍵]←⍺[⍺⍸⍵]}⌿⊢∘⊂⌸d⊣p←⍳≢d   ⍝ Parent vector p
-          ⍝ Descendant of pkgs and key≡"runtime"
+     ⍝ Descendant of pkgs and key≡"runtime"
      pkg_name←⎕C⊃¨'/'(≠⊆⊢)¨k   ⍝ e.g. Clock/1.0.3 → Clock
      pkgrt←(k∊⊂'runtime')(∧⍤1){⍵∨⍵[p]}⍤1⍣≡pkg_name(∊⍤1 0)⊃¨⎕C pkgs
-          ⍝ Child of "runtime" key is path to .dll
-          ⍝    file name    key  parent is "runtime"
-                   ⍝ dll←⊃∘⌽¨'/'(≠⊆⊢)¨k⌿⍤1⍨(⊂p)⌷⍤1⊢pkgrt
+     ⍝ Child of "runtime" key is path to .dll
+     ⍝    file name    key  parent is "runtime"
+              ⍝ dll←⊃∘⌽¨'/'(≠⊆⊢)¨k⌿⍤1⍨(⊂p)⌷⍤1⊢pkgrt
      dll←∊¨1↓¨⎕NPARTS(∨⌿pkgrt[;p])/k
      using_paths←(project_dir,'/published/')∘,¨dll
-     
+
      (folder name)←2↑⎕NPARTS ¯10↓deps
-     :If ⎕NEXISTS dll←(∊folder name),'.dll'
+     :If include_primary
+     :AndIf ⎕NEXISTS dll←(∊folder name),'.dll'
          using_paths,←⊂dll ⍝ Include primary DLL
      :EndIf
-     
+
  :Else ⍝ No deps.json file
      ∘∘∘ ⍝ Framework? Now what?!
      using_paths←{(~(2⊃¨⎕NPARTS ⍵)∊⊂project_name)/⍵}(⊃⎕NINFO⍠1⊢project_dir,'/published/*.dll')

--- a/Distribution/NuGet.apls
+++ b/Distribution/NuGet.apls
@@ -186,6 +186,18 @@ mine←name{(((≢⍺)↑¨⍕¨⍵)∊⊂⍺)/⍵}assemblies
 ∇
 
 ∇ using_paths←Using args;deps;d;k;v;t;pkg_name;pkgrt;dll;pkgs;ns;jsname;tgts;z;dlls;children;p;folder;name;project_dir;opts;opts_mat;include_primary;exclude_pkgs;include_pkgs;all_pkgs
+   ⍝ Return list of DLL paths for ⎕USING based on a primary DLL and the direct dependencies for a dotnet project published via NuGet
+   ⍝ args is expected to have one of three forms:
+   ⍝ 1. a string signifying the project directory; or
+   ⍝ 2. a list with the project directory as first element and a key-value pairs as other elements; or
+   ⍝ 3. a list of key-value pairs
+   ⍝
+   ⍝ The key-value part of args is interpreted as a map from options to values. Currently the following options are supported:
+   ⍝ * project_dir is the project directory; it must be signified if args is a pure list of key-value pairs
+   ⍝ * include_primary is a boolean signifying whether (1) or not (0) the path to the primary DLL is included in the output
+   ⍝ * exclude_pkgs is a list of package names (without version number!) to be excluded in the output
+   ⍝ * include_pkgs is a list of package names (without version number!) to be included in the output
+   ⍝ The parameter exclude_pkgs takes precedence over include_pkgs and giving include_pkgs a value of ⍬ means to include all packages.
 
  :If 2>|≡args
      project_dir opts←args ⍬
@@ -197,13 +209,13 @@ mine←name{(((≢⍺)↑¨⍕¨⍵)∊⊂⍺)/⍵}assemblies
      opts←args
  :EndIf
 
- include_primary include_pkgs exclude_pkgs←1 (⊂⍬) (⊂⍬){⊃(opts_mat,⍺)⌷⍨2,(1⌷opts_mat←⍉↑args)⍳⊂⍵}¨'include_primary' 'include_pkgs' 'exclude_pkgs'
+ include_primary include_pkgs exclude_pkgs←1(⊂⍬)(⊂⍬){⊃(opts_mat,⍺)⌷⍨2,(1⌷opts_mat←⍉↑args)⍳⊂⍵}¨'include_primary' 'include_pkgs' 'exclude_pkgs'
 
  jsname←7162⌶ ⍝ JSON Translate Name
 
  pkgs←(~exclude_pkgs∊⍥⎕C⍨1⊃¨all_pkgs)/all_pkgs←Packages project_dir
  :If 0<≢include_pkgs
-    pkgs←(include_pkgs∊⍥⎕C⍨1⊃¨pkgs)/pkgs
+     pkgs←(include_pkgs∊⍥⎕C⍨1⊃¨pkgs)/pkgs
  :EndIf
 
 
@@ -232,9 +244,11 @@ mine←name{(((≢⍺)↑¨⍕¨⍵)∊⊂⍺)/⍵}assemblies
      using_paths←(project_dir,'/published/')∘,¨dll
 
      (folder name)←2↑⎕NPARTS ¯10↓deps
+
+     ⍝ Possibly include primary DLL
      :If include_primary
      :AndIf ⎕NEXISTS dll←(∊folder name),'.dll'
-         using_paths,←⊂dll ⍝ Include primary DLL
+         using_paths,←⊂dll
      :EndIf
 
  :Else ⍝ No deps.json file

--- a/StartupSession/NuGet/Using.aplf
+++ b/StartupSession/NuGet/Using.aplf
@@ -7,9 +7,12 @@
    ⍝
    ⍝ The key-value part of args is interpreted as a map from options to values. Currently the following options are supported:
    ⍝ * project_dir is the project directory; it must be signified if args is a pure list of key-value pairs
-   ⍝ * include_primary is a boolean signifying whether (1) or not (0) the path to the primary DLL is included in the output
+   ⍝ * include_primary is a boolean signifying whether (1) or not (0) the path to the primary DLL is included in the output.
+   ⍝   Its standard value is 1.
    ⍝ * exclude_pkgs is a list of package names (without version number!) to be excluded in the output
+   ⍝   Its standard value is ⍬
    ⍝ * include_pkgs is a list of package names (without version number!) to be included in the output
+   ⍝   Its standard value is ⍬
    ⍝ The parameter exclude_pkgs takes precedence over include_pkgs and giving include_pkgs a value of ⍬ means to include all packages.
 
  :If 2>|≡args

--- a/StartupSession/NuGet/Using.aplf
+++ b/StartupSession/NuGet/Using.aplf
@@ -1,4 +1,16 @@
  using_paths←Using args;deps;d;k;v;t;pkg_name;pkgrt;dll;pkgs;ns;jsname;tgts;z;dlls;children;p;folder;name;project_dir;opts;opts_mat;include_primary;exclude_pkgs;include_pkgs;all_pkgs
+   ⍝ Return list of DLL paths for ⎕USING based on a primary DLL and the direct dependencies for a dotnet project published via NuGet
+   ⍝ args is expected to have one of three forms:
+   ⍝ 1. a string signifying the project directory; or
+   ⍝ 2. a list with the project directory as first element and a key-value pairs as other elements; or
+   ⍝ 3. a list of key-value pairs
+   ⍝
+   ⍝ The key-value part of args is interpreted as a map from options to values. Currently the following options are supported:
+   ⍝ * project_dir is the project directory; it must be signified if args is a pure list of key-value pairs
+   ⍝ * include_primary is a boolean signifying whether (1) or not (0) the path to the primary DLL is included in the output
+   ⍝ * exclude_pkgs is a list of package names (without version number!) to be excluded in the output
+   ⍝ * include_pkgs is a list of package names (without version number!) to be included in the output
+   ⍝ The parameter exclude_pkgs takes precedence over include_pkgs and giving include_pkgs a value of ⍬ means to include all packages.
 
  :If 2>|≡args
      project_dir opts←args ⍬
@@ -10,13 +22,13 @@
      opts←args
  :EndIf
 
- include_primary include_pkgs exclude_pkgs←1 (⊂⍬) (⊂⍬){⊃(opts_mat,⍺)⌷⍨2,(1⌷opts_mat←⍉↑args)⍳⊂⍵}¨'include_primary' 'include_pkgs' 'exclude_pkgs'
+ include_primary include_pkgs exclude_pkgs←1(⊂⍬)(⊂⍬){⊃(opts_mat,⍺)⌷⍨2,(1⌷opts_mat←⍉↑args)⍳⊂⍵}¨'include_primary' 'include_pkgs' 'exclude_pkgs'
 
  jsname←7162⌶ ⍝ JSON Translate Name
 
  pkgs←(~exclude_pkgs∊⍥⎕C⍨1⊃¨all_pkgs)/all_pkgs←Packages project_dir
  :If 0<≢include_pkgs
-    pkgs←(include_pkgs∊⍥⎕C⍨1⊃¨pkgs)/pkgs
+     pkgs←(include_pkgs∊⍥⎕C⍨1⊃¨pkgs)/pkgs
  :EndIf
 
 
@@ -45,9 +57,11 @@
      using_paths←(project_dir,'/published/')∘,¨dll
 
      (folder name)←2↑⎕NPARTS ¯10↓deps
+
+     ⍝ Possibly include primary DLL
      :If include_primary
      :AndIf ⎕NEXISTS dll←(∊folder name),'.dll'
-         using_paths,←⊂dll ⍝ Include primary DLL
+         using_paths,←⊂dll
      :EndIf
 
  :Else ⍝ No deps.json file

--- a/StartupSession/NuGet/Using.aplf
+++ b/StartupSession/NuGet/Using.aplf
@@ -1,6 +1,25 @@
- using_paths←Using project_dir;deps;d;k;v;t;pkg_name;pkgrt;dll;pkgs;ns;jsname;tgts;z;dlls;children;p;folder;name
+ using_paths←Using args;deps;d;k;v;t;pkg_name;pkgrt;dll;pkgs;ns;jsname;tgts;z;dlls;children;p;folder;name;project_dir;opts;opts_mat;include_primary;exclude_pkgs;include_pkgs;all_pkgs
+
+ :If 2>|≡args
+     project_dir opts←args ⍬
+ :ElseIf 2>|≡⊃args
+     project_dir←⊃args
+     opts←1↓args
+ :Else
+     project_dir←⊃opts_mat⌷⍨2,(1⌷opts_mat←⍉↑args)⍳⊂'project_dir'
+     opts←args
+ :EndIf
+
+ include_primary include_pkgs exclude_pkgs←1 (⊂⍬) (⊂⍬){⊃(opts_mat,⍺)⌷⍨2,(1⌷opts_mat←⍉↑args)⍳⊂⍵}¨'include_primary' 'include_pkgs' 'exclude_pkgs'
+
  jsname←7162⌶ ⍝ JSON Translate Name
- pkgs←Packages project_dir
+
+ pkgs←(~exclude_pkgs∊⍥⎕C⍨1⊃¨all_pkgs)/all_pkgs←Packages project_dir
+ :If 0<≢include_pkgs
+    pkgs←(include_pkgs∊⍥⎕C⍨1⊃¨pkgs)/pkgs
+ :EndIf
+
+
  :If 0≠≢deps←findfile project_dir,'/*.deps.json'
  :OrIf 0≠≢deps←findfile project_dir,'/published/*.deps.json'
 
@@ -17,7 +36,7 @@
      ⍝ Depth, Key, Value, Type
      {}2{p[⍵]←⍺[⍺⍸⍵]}⌿⊢∘⊂⌸d⊣p←⍳≢d   ⍝ Parent vector p
      ⍝ Descendant of pkgs and key≡"runtime"
-     pkg_name←⎕C ⊃¨'/'(≠⊆⊢)¨k   ⍝ e.g. Clock/1.0.3 → Clock
+     pkg_name←⎕C⊃¨'/'(≠⊆⊢)¨k   ⍝ e.g. Clock/1.0.3 → Clock
      pkgrt←(k∊⊂'runtime')(∧⍤1){⍵∨⍵[p]}⍤1⍣≡pkg_name(∊⍤1 0)⊃¨⎕C pkgs
      ⍝ Child of "runtime" key is path to .dll
      ⍝    file name    key  parent is "runtime"
@@ -26,7 +45,8 @@
      using_paths←(project_dir,'/published/')∘,¨dll
 
      (folder name)←2↑⎕NPARTS ¯10↓deps
-     :If ⎕NEXISTS dll←(∊folder name),'.dll'
+     :If include_primary
+     :AndIf ⎕NEXISTS dll←(∊folder name),'.dll'
          using_paths,←⊂dll ⍝ Include primary DLL
      :EndIf
 


### PR DESCRIPTION
This PR adds the possibility to supply optional parameters to `Using`. Since there is both a desire to get Using for a selection of packages (cf. #1) and to exclude the primary DLL (cf. #5) the following options are supported:

* _project_dir_ is the primary option and signifies the path to the project directory
* _include_primary_ is a boolean signifying whether (1) or not (0) the path to the primary DLL is included in the output; its standard value is 1
* _exclude_pkgs_ is a list of package names (without version number) to be excluded in the output; as standard no package is excluded
* _include_pkgs_ is a list of package names (without version number) to be included in the output; as standard all packages are included

The parameter exclude_pkgs takes precedence over include_pkgs and giving include_pkgs a value of ⍬ means to include all packages.

resolves #1 
resolves #5