### PR TITLE
<Add> made more resilient on Linux and Mac OS, <CDM> added

### DIFF
--- a/APLSource/NuGet/Add.aplf
+++ b/APLSource/NuGet/Add.aplf
@@ -1,7 +1,7 @@
- r←Add args;project_dir;newpkgs;new;p;newv;old;oldv;pkgs;i;same;bad;add;z;mask;v
- ⍝ ⊃args: project_dir
- ⍝ 1↓args: new packages, either 'name' or 'name/version'
- ⍝ e.g. Add 'c:\tmp\clocktest\ 'Clock'
+ r←Add args;project_dir;newpkgs;new;p;newv;old;oldv;pkgs;i;same;bad;add;z;mask;v;cmd
+⍝ ⊃args: project_dir
+⍝ 1↓args: new packages, either 'name' or 'name/version'
+⍝ e.g. Add 'c:\tmp\clocktest\ 'Clock'
 
  args←,⊆args
  project_dir←⊃args
@@ -20,17 +20,18 @@
 
  same←⍸new∊old            ⍝ Already registered
  same←(⍳≢new)∊(newv[same]≡oldv[old⍳new[same]])/i ⍝ With the same version
- ⍝ research suggests the following is wrong, just "dotnet add" again to change version
- ⍝:If 0≠≢i←i/⍨newv[i]≢oldv[old⍳new[i]]
- ⍝    ('already registered with a different version: ',,⍕pkgs[old⍳new[i]])⎕SIGNAL 11
- ⍝:EndIf
+⍝ research suggests the following is wrong, just "dotnet add" again to change version
+⍝:If 0≠≢i←i/⍨newv[i]≢oldv[old⍳new[i]]
+⍝ ('already registered with a different version: ',,⍕pkgs[old⍳new[i]])⎕SIGNAL 11
+⍝:EndIf
 
  bad←0⍨¨new
  r←''
  r,←'Already registered: '∘,¨same/new
  :For i :In ⍸~same
      add←(i⊃new),(0≠≢v)/' --version ',v←i⊃newv
-     z←⎕CMD'dotnet add ',project_dir,' package ',add
+     cmd←'dotnet add ',project_dir,' package ',add
+     z←CMD cmd
      mask←∨/¨'error: '∘⍷¨z
      :If bad[i]←∨/mask
          r,←⊂'Error: ',add

--- a/APLSource/NuGet/CMD.aplf
+++ b/APLSource/NuGet/CMD.aplf
@@ -1,0 +1,25 @@
+ r←CMD cmd;qdmx;⎕RL;tempFilename
+⍝ Cover function for ⎕CMD. Deals with the fact that ⎕CMD behaves differently on Windows compared with Linux and Mac OS
+ r←''
+ ⎕RL←⍬
+ tempFilename←(739⌶0),'/',⎕AN,'-',⍕100000+?10000000
+ :Trap 11
+     r←⎕CMD cmd,'>',tempFilename,' 2>&1'
+     :If 0=≢r
+         :If ⎕NEXISTS tempFilename
+             r←⊃⎕NGET tempFilename 1
+         :Else
+             'Something went wrong'⎕SIGNAL 11
+         :EndIf
+     :EndIf
+ :Else
+     qdmx←⎕DMX
+     :If ⎕NEXISTS tempFilename
+         r←⊃⎕NGET tempFilename 1
+     :Else
+         3 ⎕NDELETE tempFilename
+         qdmx.EM ⎕SIGNAL qdmx.EN
+     :EndIf
+ :EndTrap
+ 3 ⎕NDELETE tempFilename
+⍝Done

--- a/cider.config
+++ b/cider.config
@@ -1,5 +1,6 @@
 {
   CIDER: {
+    cider_version: "0.41.1",
     dependencies: {
       nuget: "nuget-dependencies",
       tatin: "tatin-dependencies",


### PR DESCRIPTION
On Windows `⎕CMD` always returns the output, while on Linux/Mac OS it throws a DOMAIN ERROR whenever the command processed has a return code that is not equal to 0. 

This is the case whenever `dotnet` fails to add a package via a call to `dotnet add`.