### PR TITLE
Use tatin's facility to exclude ⎕io and ⎕mk.apla

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.apl? linguist-language=APL

--- a/APLSource/NuGet/Version.aplf
+++ b/APLSource/NuGet/Version.aplf
@@ -1,2 +1,2 @@
 version←Version
-version←'0.2.1'
+version←'0.2.2'

--- a/APLSource/apl-package.json
+++ b/APLSource/apl-package.json
@@ -8,6 +8,7 @@
   io: 1,
   license: "MIT",
   lx: "",
+  exclude : "⎕IO.apla, ⎕ML.apla",
   maintainer: "support@dyalog.com",
   minimumAplVersion: "19.0",
   ml: 1,
@@ -19,5 +20,5 @@
   source: "NuGet",
   tags: "dotnet,nuget,packages",
   userCommandScript: "",
-  version: "0.2.1",
+  version: "0.2.2",
 }


### PR DESCRIPTION
UTF-8 chars in filenames don't play well with zip. The files are needed when using nuget directly (as in not installed via tatin), but not needed when used as a package.